### PR TITLE
Add configurable metadata endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Usage
 |       Flag         |            Description         |
 | ------------------ | ------------------------------ |
 | `config`           | Path to an optional config file. Options specified on the CLI always take precedence.
+| `metadata-url`     | Metadata endpoint used when querying the Rancher Metadata API. Default: `http://rancher-metadata`
 | `metadata-version` | Metadata version string used when querying the Rancher Metadata API. Default: `latest`.
 | `include-inactive` | *Not yet implemented*
 | `interval`         | Interval (in seconds) for polling the Metadata API for changes. Default: `5`.

--- a/config.go
+++ b/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	LogLevel        string     `toml:"log-level"`
 	OneTime         bool       `toml:"onetime"`
 	IncludeInactive bool       `toml:"include-inactive"`
+	MetadataUrl     string     `toml:"metadata-url"`
 	Templates       []Template `toml:"template"`
 }
 
@@ -31,6 +32,7 @@ type Template struct {
 func initConfig() (*Config, error) {
 	config := Config{
 		MetadataVersion: "latest",
+		MetadataUrl:     "http://rancher-metadata",
 		Interval:        5,
 		LogLevel:        "info",
 	}
@@ -92,6 +94,8 @@ func overwriteConfigFromFlags(conf *Config) {
 		switch f.Name {
 		case "interval":
 			conf.Interval = interval
+		case "metadata-url":
+			conf.MetadataUrl = metadataUrl
 		case "metadata-version":
 			conf.MetadataVersion = metadataVersion
 		case "onetime":
@@ -116,6 +120,9 @@ func overwriteConfigFromEnv(conf *Config) {
 		} else {
 			log.Warnf("Invalid value for environment variable 'RANCHER_GEN_INTERVAL': %s", env)
 		}
+	}
+	if env = os.Getenv("RANCHER_GEN_METADATA_URL"); len(env) > 0 {
+		conf.MetadataUrl = env
 	}
 	if env = os.Getenv("RANCHER_GEN_METADATA_VER"); len(env) > 0 {
 		conf.MetadataVersion = env

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ var (
 
 	configFile      string
 	metadataVersion string
+	metadataUrl     string
 	logLevel        string
 	checkCmd        string
 	notifyCmd       string
@@ -30,6 +31,7 @@ func init() {
 	log.SetOutput(os.Stdout)
 
 	flag.StringVar(&configFile, "config", "", "Path to optional config file")
+	flag.StringVar(&metadataUrl, "metadata-url", "http://rancher-metadata", "Metadata endpoint to use for querying the Metadata API")
 	flag.StringVar(&metadataVersion, "metadata-version", "latest", "Metadata version to use for querying the Metadata API")
 	flag.IntVar(&interval, "interval", 60, "Interval (in seconds) for polling the Metadata API for changes")
 	flag.BoolVar(&includeInactive, "include-inactive", false, "Not yet implemented")

--- a/runner.go
+++ b/runner.go
@@ -21,10 +21,6 @@ import (
 	"github.com/rancher/go-rancher-metadata/metadata"
 )
 
-var (
-	MetadataURL = "http://rancher-metadata"
-)
-
 type runner struct {
 	Config  *Config
 	Client  metadata.Client
@@ -34,7 +30,7 @@ type runner struct {
 }
 
 func NewRunner(conf *Config) (*runner, error) {
-	u, _ := url.Parse(MetadataURL)
+	u, _ := url.Parse(conf.MetadataUrl)
 	u.Path = path.Join(u.Path, conf.MetadataVersion)
 
 	log.Infof("Initializing Rancher Metadata client (version %s)", conf.MetadataVersion)


### PR DESCRIPTION
Useful when testing, or for external services interacting
with a proxied metadata endpoint.

In addition, add --metadata-url command line option
and RANCHER_GEN_METADATA_URL environment values for
overriding the same.